### PR TITLE
Update list of default gems

### DIFF
--- a/rbenv-default-gems
+++ b/rbenv-default-gems
@@ -1,2 +1,3 @@
-bundler
+bundler <2
 git-smart
+knuckle_cluster


### PR DESCRIPTION
Prevent bundler from going >= version 2 as its pretty new and not supported by my current workplace's build pipelines